### PR TITLE
Use Silero VAD instead

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -95,7 +95,7 @@ def main():
     parser.add_argument(
         "--max-length",
         type=float,
-        default=3.0,
+        default=10.0,
         help="Maximum length of each segment in seconds",
     )
     parser.add_argument(
@@ -162,11 +162,11 @@ def main():
                 save_transcription(srt_text, audio_file, args.output_dir)
 
             except Exception as e:
-                logger.error("Error transcribing %s: %s", audio_file, str(e))
+                logger.error("Error transcribing %s: %s", audio_file, e)
                 continue
 
     except Exception as e:
-        logger.error("Error during initialization: %s", str(e))
+        logger.error("Error during initialization: %s", e)
         raise
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ resampy
 torch
 torchaudio
 transformers[onnx]
+silero-vad

--- a/transcriber/AutoTranscriber.py
+++ b/transcriber/AutoTranscriber.py
@@ -9,6 +9,7 @@ from resampy.core import resample
 from tqdm.auto import tqdm
 
 from denoiser import denoiser
+from silero_vad import load_silero_vad, get_speech_timestamps
 from transcriber.Transcriber import Transcriber, TranscribeResult
 
 logger = logging.getLogger(__name__)
@@ -23,10 +24,7 @@ class AutoTranscriber(Transcriber):
         super().__init__(**kwargs)
 
         # Initialize models
-        self.vad_model = AutoModel(
-            model="fsmn-vad",
-            max_single_segment_time=self.max_length_seconds * 1000,
-        )
+        self.vad_model = load_silero_vad()
         self.asr_model = AutoModel(
             model="iic/SenseVoiceSmall",
             vad_model=None,  # We'll handle VAD separately
@@ -48,7 +46,7 @@ class AutoTranscriber(Transcriber):
             List[TranscribeResult]: List of transcription results
         """
         # Load and preprocess audio
-        speech, sr = librosa.load(audio_file, sr=self.sr)
+        speech, sr = librosa.load(audio_file, sr=None)
 
         if self.use_denoiser:
             logger.info("Denoising speech...")
@@ -62,22 +60,23 @@ class AutoTranscriber(Transcriber):
         logger.info("Segmenting speech...")
 
         start_time = time.time()
-        vad_results = self.vad_model.generate(input=speech, disable_pbar=True)
+        vad_results = get_speech_timestamps(
+            speech,
+            self.vad_model,
+            sampling_rate=16_000,
+            # max_speech_duration_s=self.max_length_seconds,
+        )
         logger.info("VAD took %.2f seconds", time.time() - start_time)
 
-        if not vad_results or not vad_results[0]["value"]:
+        if not vad_results:
             return []
-
-        vad_segments = vad_results[0]["value"]
 
         # Process each segment
         results = []
 
         start_time = time.time()
-        for segment in tqdm(vad_segments, desc="Transcribing"):
-            start_sample = int(segment[0] * 16)  # Convert ms to samples
-            end_sample = int(segment[1] * 16)
-            segment_audio = speech[start_sample:end_sample]
+        for segment in tqdm(vad_results, desc="Transcribing"):
+            segment_audio = speech[segment["start"] : segment["end"]]
 
             # Get ASR results for segment
             asr_result = self.asr_model.generate(
@@ -86,9 +85,8 @@ class AutoTranscriber(Transcriber):
 
             if not asr_result:
                 continue
-
-            start_time = max(0, segment[0] / 1000.0 + self.offset_in_seconds)
-            end_time = segment[1] / 1000.0 + self.offset_in_seconds
+            start_time = max(0, segment['start'] / 16_000.0 + self.offset_in_seconds)
+            end_time = segment['end'] / 16_000.0  + self.offset_in_seconds
 
             # Convert ASR result to TranscribeResult format
             segment_result = TranscribeResult(
@@ -99,7 +97,6 @@ class AutoTranscriber(Transcriber):
             results.append(segment_result)
 
         logger.info("ASR took %.2f seconds", time.time() - start_time)
-
         # Apply Chinese conversion if needed
         start_time = time.time()
         results = self._postprocessing(results)

--- a/transcriber/Transcriber.py
+++ b/transcriber/Transcriber.py
@@ -28,7 +28,7 @@ class Transcriber:
         use_denoiser=False,
         with_punct=True,
         offset_in_seconds=-0.25,
-        max_length_seconds=5,
+        max_length_seconds=10,
         sr=16000,
     ):
         self.corrector = corrector


### PR DESCRIPTION
The existing VAD model tends to output segments longer than 3 seconds about 70 % of the time. With the 3 s default in cli.py, this effectively bypasses VAD segmentation for 70 % of the audio—simply clipping it into 3 s chunks.

This leads to very unnatural breaks, which deteriorate ASR quality. Raising the maximum segment length alone doesn’t solve the problem— for YouTube captions we still want short, natural segments, which I assume is why the default was set to 3 s in the first place.

I collected the following statistics for both VADs on five videos (no max‐length setting):

### Distribution by segment duration
Old VAD (138 segments)

0–3 s: 41 (29.7 %)
3–6 s: 10 (7.3 %)
6–10 s: 15 (10.9 %)
10–20 s: 22 (15.9 %)
20–30 s: 14 (10.1 %)
≥ 30 s: 36 (26.1 %)

New VAD (545 segments)

0–3 s: 267 (49.0 %)
3–6 s: 161 (29.5 %)
6–10 s: 64 (11.7 %)
10–20 s: 34 (6.2 %)
20–30 s: 9 (1.7 %)
≥ 30 s: 10 (1.8 %)

### ASR output comparison
Old segmentation

```
00:00:43,560 --> 00:00:46,570
多去到十萬美金 google 蘋果

00:00:46,570 --> 00:00:49,580
明軟等等嘅外國企業到紛佛將歐洲總

00:00:49,580 --> 00:00:52,590
部搬到當地佢點解可以咁驚

New segmentation

```
00:00:39,528 --> 00:00:45,316
今日愛爾蘭人均 GDP 竟然可以高出英國日倍有多去到十萬美金

00:00:45,672 --> 00:00:50,916
Google、Apple、Microsoft 等等嘅外國企業都紛紛將歐洲總部搬到當地

00:00:51,336 --> 00:00:52,708
佢點解可以咁勁
```


With the old VAD, segment boundaries land mid‑word, causing inaccurate ASR output.
You can see “明軟” vs “微軟” , "咁驚" vs "咁勁" in the example.  The new VAD produces much more natural breaks and improves ASR accuracy.

### Default value of max segment length
I set it to be 10 so that we take the VAD output 90% of the time. Feel free to suggest otherwise.